### PR TITLE
fix: docker.io `KeyError` issue

### DIFF
--- a/docking-station-app/src/app/api/routes/__init__.py
+++ b/docking-station-app/src/app/api/routes/__init__.py
@@ -1,7 +1,9 @@
+from .regctl import router as regctl_router
 from .root import router as root_router
 from .stacks import router as stacks_router
 
 __all__ = [
+    'regctl_router',
     'root_router',
     'stacks_router',
 ]

--- a/docking-station-app/src/app/api/routes/regctl.py
+++ b/docking-station-app/src/app/api/routes/regctl.py
@@ -1,0 +1,34 @@
+from logging import getLogger
+
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+from ..schemas import RegctlImageInspect
+from ..services import regctl as regctl_services
+from ..settings import get_app_settings
+
+__all__ = [
+    'router',
+]
+
+logger = getLogger(__name__)
+app_settings = get_app_settings()
+router = APIRouter()
+
+
+@router.get('/digest', response_class=PlainTextResponse)
+async def get_image_remote_digest(tag: str, no_cache: bool = False):
+    return await regctl_services.get_image_remote_digest(
+        repo_tag=tag,
+        no_cache=no_cache,
+        reraise=True,
+    )
+
+
+@router.get('/inspect', response_model=RegctlImageInspect)
+async def get_image_inspect(tag: str, no_cache: bool = False):
+    return await regctl_services.get_image_inspect(
+        repo_tag=tag,
+        no_cache=no_cache,
+        reraise=True,
+    )

--- a/docking-station-app/src/app/api/routes/root.py
+++ b/docking-station-app/src/app/api/routes/root.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, status
 from .. import routes
 from ..schemas import DockerStack, DockerStackRootModel, GetStatsResponse
 from ..settings import AppSettings, get_app_settings
+from .regctl import router as regctl_router
 from .stacks import router as stacks_router
 
 __all__ = [
@@ -14,7 +15,8 @@ __all__ = [
 app_settings = get_app_settings()
 router = APIRouter()
 
-router.include_router(stacks_router, prefix='/stacks')
+router.include_router(stacks_router, tags=['Stacks'], prefix='/stacks')
+router.include_router(regctl_router, tags=['Regctl'], prefix='/regctl')
 
 
 @router.get('',

--- a/docking-station-app/src/app/api/routes/stacks.py
+++ b/docking-station-app/src/app/api/routes/stacks.py
@@ -23,7 +23,7 @@ router = APIRouter()
 task_store: dict[tuple[str, str], tuple[Thread, asyncio.Queue[MessageDict]]] = {}
 
 
-@router.get('', tags=['[GET] Stacks'], response_model=list[DockerStackResponse])
+@router.get('', response_model=list[DockerStackResponse])
 @cached(expire=app_settings.server.cache_control_max_age_seconds)
 async def list_compose_stacks(no_cache: bool = False, include_stopped: bool = False):
     return await docker_services.list_compose_stacks(
@@ -32,7 +32,7 @@ async def list_compose_stacks(no_cache: bool = False, include_stopped: bool = Fa
     )
 
 
-@router.get('/{stack}', tags=['[GET] Stacks'], response_model=DockerStackResponse)
+@router.get('/{stack}', response_model=DockerStackResponse)
 async def get_compose_stack(stack: str, no_cache: bool = False):
     try:
         return await docker_services.get_compose_stack(
@@ -47,7 +47,7 @@ async def get_compose_stack(stack: str, no_cache: bool = False):
         ) from exc
 
 
-@router.get('/{stack}/{service}', tags=['[GET] Stacks'], response_model=DockerContainerResponse)
+@router.get('/{stack}/{service}', response_model=DockerContainerResponse)
 async def get_compose_service_container(stack: str, service: str, no_cache: bool = False):
     try:
         return await docker_services.get_compose_service_container(
@@ -63,7 +63,7 @@ async def get_compose_service_container(stack: str, service: str, no_cache: bool
         ) from exc
 
 
-@router.post('/{stack}/{service}/task', tags=['[UPDATE] Stacks'], response_model=StartComposeStackServiceUpdateTaskResponse)
+@router.post('/{stack}/{service}/task', response_model=StartComposeStackServiceUpdateTaskResponse)
 async def create_compose_stack_service_update_task(stack: str, service: str, request_body: DockerStackUpdateRequest):
     task_thread, message_queue = docker_services.update_compose_stack_ws(
         stack_name=stack,
@@ -82,7 +82,7 @@ async def create_compose_stack_service_update_task(stack: str, service: str, req
     )
 
 
-@router.get('/{stack}/{service}/task', tags=['[UPDATE] Stacks'], response_model=list[MessageDictResponse])
+@router.get('/{stack}/{service}/task', response_model=list[MessageDictResponse])
 async def poll_compose_stack_service_update_task(stack: str, service: str):
     if (stack, service) not in task_store:
         return []

--- a/docking-station-app/src/app/api/services/docker.py
+++ b/docking-station-app/src/app/api/services/docker.py
@@ -121,8 +121,12 @@ async def list_images(repository_or_tag: str = None,
             version=version,
         )
 
+    clean_repository_or_tag = repository_or_tag
+    for prefix in app_settings.server.python_on_whales__ignored_image_prefixes:
+        clean_repository_or_tag = clean_repository_or_tag.removeprefix(prefix)
+
     _images = docker.image.list(
-        repository_or_tag=repository_or_tag,
+        repository_or_tag=clean_repository_or_tag,
         filters=filters or {},
     )
     images = await asyncio.gather(*[

--- a/docking-station-app/src/app/api/settings/settings.py
+++ b/docking-station-app/src/app/api/settings/settings.py
@@ -52,6 +52,8 @@ class ServerSettings(BaseSettings, CamelCaseAliasedBaseModel):
                                                                          'org.opencontainers.image.source'])
     possible_image_version_labels: list[str] = Field(default_factory=lambda: ['org.label-schema.version',
                                                                               'org.opencontainers.image.version'])
+    python_on_whales__ignored_image_prefixes: list[str] = Field(default_factory=lambda: ['docker.io/',
+                                                                                         'docker.io/library/'])
     time_until_update_is_mature: Interval = '1w'
 
     @property

--- a/settings.template.yml
+++ b/settings.template.yml
@@ -12,6 +12,9 @@ server:
   possible_image_version_labels:  # order matters!
     - org.label-schema.version
     - org.opencontainers.image.version
+  python_on_whales__ignored_image_prefixes:
+    - docker.io/library/
+    - docker.io/
   time_until_update_is_mature: 1w
 
 auto_updater:


### PR DESCRIPTION
Fix for #7

feat(api): added `/api/regctl/` route with `inspect` and `digest` endpoints

chore(api): reorganized `/api/docs` tags